### PR TITLE
Changed schema to persist data based on pen users

### DIFF
--- a/db/migrate/20190421175524_remove_pump_or_mdi_from_users.rb
+++ b/db/migrate/20190421175524_remove_pump_or_mdi_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePumpOrMdiFromUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :pump_or_mdi, :string
+  end
+end

--- a/db/migrate/20190421181556_update_pump_inputs_name.rb
+++ b/db/migrate/20190421181556_update_pump_inputs_name.rb
@@ -1,0 +1,5 @@
+class UpdatePumpInputsName < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :pump_inputs, :basal_dose
+  end
+end

--- a/db/migrate/20190421185932_create_bolus_dose.rb
+++ b/db/migrate/20190421185932_create_bolus_dose.rb
@@ -1,0 +1,10 @@
+class CreateBolusDose < ActiveRecord::Migration[5.1]
+  def change
+    create_table :bolus_doses do |t|
+      t.float :amount
+      t.time :timestamp
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190414172717) do
+ActiveRecord::Schema.define(version: 20190421185932) do
 
-  create_table "glucose_readings", force: :cascade do |t|
-    t.float "bg_value"
+  create_table "basal_dose", force: :cascade do |t|
+    t.float "amount"
     t.time "time_stamp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "pump_inputs", force: :cascade do |t|
+  create_table "bolus_doses", force: :cascade do |t|
     t.float "amount"
+    t.time "timestamp"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "glucose_readings", force: :cascade do |t|
+    t.float "bg_value"
     t.time "time_stamp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -31,7 +38,6 @@ ActiveRecord::Schema.define(version: 20190414172717) do
     t.string "last_name"
     t.string "basal_insulin"
     t.string "bolus_insulin"
-    t.string "pump_or_mdi"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Renamed columns and a table and created a table.

Schema updated based on new app direction. For pen users only. Needed another table to store multiple doses a day.