### PR TITLE
Column name now matches ruby naming convention

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,8 +40,10 @@ class UsersController < ApplicationController
 
     private
     def user_params
-        params.permit(:users).permit(:first_name, :last_name, :basal_insulin, :bolus_insulin)
+        params.require(:users).permit(:first_name, :last_name, :basal_insulin, :bolus_insulin)
     end
 end
 #In the private class above, in order to get around the error I was encountering (according to stack overflow)
 #I changed params.require(:users) > params.permit(:users)
+#As of 5/10/19 I changed user_params to params.require and now my data that is being input via fields on the user creation
+#is displaying - No errors so far navigating through the app

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,4 +14,4 @@
 <br>
 <%= link_to 'Edit', edit_user_path(@user) %>
 <br>
-<%= link_to 'Back to The Dashboard', users_path %><br>
+<%= link_to 'Yup! Back to The Dashboard', users_path %><br>

--- a/db/migrate/20190510124630_update_bolus_dose_time.rb
+++ b/db/migrate/20190510124630_update_bolus_dose_time.rb
@@ -1,0 +1,7 @@
+class UpdateBolusDoseTime < ActiveRecord::Migration[5.1]
+  def change
+    change_table :bolus_doses do |t|
+    t.rename :timestamp, :time_stamp
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190427191748) do
+ActiveRecord::Schema.define(version: 20190510124630) do
 
   create_table "basal_doses", force: :cascade do |t|
     t.float "amount"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20190427191748) do
 
   create_table "bolus_doses", force: :cascade do |t|
     t.float "amount"
-    t.time "timestamp"
+    t.time "time_stamp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Changed the column name of _timestamp_ > _time_stamp_ on the BolusDose DB table