### PR TITLE
GlucoseReadings migration - updated timestamp field to datetime

### DIFF
--- a/db/migrate/20190912122439_glucose_readings_update.rb
+++ b/db/migrate/20190912122439_glucose_readings_update.rb
@@ -1,0 +1,5 @@
+class GlucoseReadingsUpdate < ActiveRecord::Migration[5.1]
+  def change
+    change_column :glucose_readings, :time_stamp, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805125218) do
+ActiveRecord::Schema.define(version: 20190912122439) do
 
   create_table "basal_doses", force: :cascade do |t|
     t.float "amount"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20190805125218) do
 
   create_table "glucose_readings", force: :cascade do |t|
     t.float "bg_value"
-    t.time "time_stamp"
+    t.datetime "time_stamp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"


### PR DESCRIPTION
Updated the timestamp field on the GlucoseReadings model to be a datetime field.

The API payload for the evgs GET request sends the display_time over in datetime format. The access tokens and doses classes are setup with datetime as well. 

I realize now that all time fields should be datetime. Need to figure out if all should be UTC or not. 

Some of the algorithms and conditionals will be using dates as well for the calculations and feedback to the user